### PR TITLE
Add a navbar to index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,15 @@
 
 <body>
 
+	<ul class="topnav w3-small">
+		<li><a href="index.html" class="active">Home</a></li>
+		<li><a href="pages/testsmells.html">Test Smell Types</a></li>
+		<li><a href="pages/testsmellexamples.html">Test Smell Examples</a></li>
+		<li><a href="pages/testsmelldetector.html">Test Smell Detector</a></li>
+		<li><a href="pages/research/home.html">Test Smell Research</a></li>
+		<li><a href="pages/testsmellpublications.html">Publications</a></li>
+	</ul>
+
     <!-- Header -->
     <header class="w3-container w3-theme w3-padding" id="myHeader">
         <div class="w3-center">


### PR DESCRIPTION
Currently, the index/homepage lacks the navigation bar common to the rest of the pages.  In order to maintain consistency and ease user navigation, we can add the nav bar to the index page as well.